### PR TITLE
Added support for older versions (<v1.7) of git's ENOENT error message

### DIFF
--- a/lib/git-fs.js
+++ b/lib/git-fs.js
@@ -29,7 +29,7 @@ var CACHE_LIFE = [36300000, 100];
 
 var gitCommands, gitDir, workTree;
 
-var gitENOENT = /fatal: Path '([^']+)' does not exist in '([0-9a-f]{40})'/;
+var gitENOENT = /fatal: (Path '([^']+)' does not exist in '([0-9a-f]{40})'|ambiguous argument '([^']+)': unknown revision or path not in the working tree.)/;
 
 // Set up the git configs for the subprocess
 var Git = module.exports = function (repo) {


### PR DESCRIPTION
Turns out when I pushed the change to my server, I realized that my older version of `git` on that machine was giving a different error message, and the RegExp wasn't catching it.

I ended up recompiling git on my server to the newest version, but it was a simple one-liner to include support for the older message.
