### PR TITLE
Should prevent ENOENT on absence of .git/packed-refs

### DIFF
--- a/lib/git-fs.js
+++ b/lib/git-fs.js
@@ -123,22 +123,36 @@ function getHeadSha(callback) {
   }
 
   var head, packedRefs, master;
-  fs.readFile(Path.join(gitDir, "packed-refs"), "ascii", function (err, result) {
-    if (err) { groupCallback(err); return; }
-    packedRefs = result;
-    checkDone();
+  
+  Path.exists(Path.join(gitDir, "packed-refs"), function (exists) {
+    if(exists) {
+      getHEAD();
+    }
+    else {
+      gitExec(["gc"],function (err) {
+        getHEAD();
+      });
+    }
   });
-  fs.readFile(Path.join(gitDir, "HEAD"), "ascii", function (err, result) {
-    if (err) { groupCallback(err); return; }
-    try {
-      head = result.match(/^ref: (.*)\n$/)[1]
-    } catch (err) { groupCallback(err); return; }
-    fs.readFile(Path.join(gitDir, head), "ascii", function (err, result) {
-      master = result || null;
+  
+  function getHEAD() {
+    fs.readFile(Path.join(gitDir, "packed-refs"), "ascii", function (err, result) {
+      if (err) { groupCallback(err); return; }
+      packedRefs = result;
       checkDone();
     });
-    checkDone();
-  });
+    fs.readFile(Path.join(gitDir, "HEAD"), "ascii", function (err, result) {
+      if (err) { groupCallback(err); return; }
+      try {
+        head = result.match(/^ref: (.*)\n$/)[1]
+      } catch (err) { groupCallback(err); return; }
+      fs.readFile(Path.join(gitDir, head), "ascii", function (err, result) {
+        master = result || null;
+        checkDone();
+      });
+      checkDone();
+    });
+  }
 
   // When they're both done, parse out the sha and return it.
   function checkDone() {


### PR DESCRIPTION
While attempting to locally test a wheat-based blog from a fresh git clone, I ran into an error similar to that described by @TooTallNate in issue #1, and I have found a way to fix the problem.  

Git creates `.git/packed-refs` on garbage collection, so the file won't exist in a fresh clone.  `git gc` can be run, however, to create the file right away; this patch should check for the existence of `.git/packed-refs`, and, if the file is absent, call `gitExec()` to run `gc` and garbage collect for us.  
