### PR TITLE
Adds Git.logBetween(from, to, callback)

### DIFF
--- a/lib/git-fs.js
+++ b/lib/git-fs.js
@@ -213,7 +213,38 @@ function gitExec(commands, encoding, callback) {
   child.stdin.end();
 }
 
+var parseSummaryLogEntry = function(entry) {
+  var id = entry.match(/^commit ([a-f0-9]{40})/)[1];
 
+  var commit = {
+    id: id,
+    message: entry.match(/\n\n([\s\S]*)/)[1].trim()
+  }
+
+  entry.match(/^[A-Z][a-z]*:.*$/gm).forEach(function (line) {
+    var matches = line.match(/^([A-Za-z]+):\s*(.*)$/);
+    commit[matches[1].toLowerCase()] = matches[2];
+  });
+
+  return commit;
+};
+
+Git.logBetween = function(from, to, callback) {
+  var commands;
+  var args = ["log", "-z", from + ".." + to]
+
+  gitExec(args, 'utf8', function(err, text) {
+    if (err) { callback(err); return; }
+    if (text.length === 0) { callback(null, []); return; }
+
+    var log = [];
+    text.split("\0").forEach(function (entry) {
+      log.push(parseSummaryLogEntry(entry));
+    });
+
+    callback(null, log);
+  });
+};
 
 var logFile = safe(function logFile(version, path, callback) {
   // Get the data from a git subprocess at the given sha hash.


### PR DESCRIPTION
I needed to get the log between two refspecs, and that's what `Git.logBetween` allows.

Given a `from` refspec, and a `to` refspec it returns an array of commit hashes, ordered by commit time.

I lifted the parsing of an individual line of the summary log from `logFile`, but only for use in `logBetween`, since that would technically change the resulting hash if used in `logFile`.

If you're happy with this as a start, I can finish that refactoring for `logFile` to use `parseSummaryLogEntry`, and add some tests for `logBetween`
