### PR TITLE
Fix bug with gitExec

### DIFF
--- a/lib/git-fs.js
+++ b/lib/git-fs.js
@@ -186,6 +186,10 @@ function getHeadSha(callback) {
 
 // Internal helper to talk to the git subprocess
 function gitExec(commands, encoding, callback) {
+  if (typeof callback === 'undefined') {
+    callback = encoding;
+    encoding = 'utf8';
+  }
   commands = gitCommands.concat(commands);
   var child = ChildProcess.spawn("git", commands);
   var stdout = [], stderr = [];


### PR DESCRIPTION
I ran into a problem with this line here: https://github.com/creationix/node-git/blob/master/lib/git-fs.js#L139

It was throwing an error because `gitExec` requires all three arguments. I've fixed that by defaulting to `"utf8"` if no encoding is given

Maybe it's simpler just to add the `"utf8"` parameter to the `getExec` call I linked above, that's up to you. I figured I would share this fix anyway
